### PR TITLE
Create table during autoupdate if not exists

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -317,8 +317,11 @@ PG.prototype.autoupdate = function (cb) {
         wait += 1;
         var fields;
         getTableStatus.call(self, model, function(err, fields){
-            if(err) console.log(err);
-            self.alterTable(model, fields, done);
+            if (!err && fields.length) {
+                self.alterTable(model, fields, done);
+            } else {
+                self.createTable(model, done);
+            }
         });
     });
 


### PR DESCRIPTION
See issue #3. I'm not sure this is the correct way to do it for PostgreSQL, but it follows the same pattern as the MySQL adapter and works for me.
