### PR TITLE
Implement like operator

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -214,13 +214,9 @@ PG.prototype.escapeName = function (name) {
 };
 
 PG.prototype.getColumns = function(model){
-    var _fields = [];
-    var props = this._models[model].properties;
-    Object.keys(props).forEach(function (key) {
-        _fields.push(key);
-    });
-    return _fields.join(', ');
-}
+    return Object.keys(this._models[model].properties).join(', ');
+}   
+
 
 PG.prototype.all = function all(model, filter, callback) {
     this.query('SELECT ' + this.getColumns(model) +  '  FROM ' + this.tableEscaped(model) + ' ' + this.toFilter(model, filter), function (err, data) {


### PR DESCRIPTION
Added LIKE operator.

```
_foo.all({where:{name:{like:'%test%'}}},function(){});
//SELECT * FROM foo WHERE name like '%test%'

_foo.all({where:{name:{like:'test%'}}},function(){});
//SELECT * FROM foo WHERE name like 'test%'

_foo.all({where:{name:{like:'%test'}}},function(){});
//SELECT * FROM foo WHERE name like '%test'

_foo.all({where:{name:{nlike:'%test%'}}},function(){});
//SELECT * FROM foo WHERE name not like '%test%'
```
