### PR TITLE
Change in node-postgres version and fix dates problems

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -131,13 +131,13 @@ PG.prototype.toFields = function (model, data, forCreate) {
 
 function dateToPostgres(val) {
     return [
-        val.getUTCFullYear(),
-        fz(val.getUTCMonth() + 1),
-        fz(val.getUTCDate())
+        val.getFullYear(),
+        fz(val.getMonth() + 1),
+        fz(val.getDate())
     ].join('-') + ' ' + [
-        fz(val.getUTCHours()),
-        fz(val.getUTCMinutes()),
-        fz(val.getUTCSeconds())
+        fz(val.getHours()),
+        fz(val.getMinutes()),
+        fz(val.getSeconds())
     ].join(':');
 
     function fz(v) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "jugglingdb": "= 0.2.x",
-    "pg": "= 0.7.2"
+    "pg": "= 0.11.2"
   },
   "devDependencies": {
     "nodeunit": "latest"


### PR DESCRIPTION
Tests were failing when updating node-postgres to v11.2 because of a missmatch in how dates where inserted and returned. Related to https://github.com/1602/jugglingdb-postgres/issues/11.
