### PR TITLE
Support arbitrary where clauses

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -242,76 +242,86 @@ PG.prototype.toFilter = function (model, filter) {
     if (filter.where) {
         var fields = [];
         var conds = filter.where;
-        Object.keys(conds).forEach(function (key) {
-            if (filter.where[key] && filter.where[key].constructor.name === 'RegExp') {
-                var regex = filter.where[key];
-                var sqlCond = '"' + key + '"';
-
-                if (regex.ignoreCase) {
-                    sqlCond += ' ~* ';
-                } else {
-                    sqlCond += ' ~ ';
-                }
-
-                sqlCond += "'"+regex.source+"'";
-
-                fields.push(sqlCond);
-
-                return;
-            }
-            if (props[key]) {
-                var filterValue = this.toDatabase(props[key], filter.where[key]);
-                if (filterValue === 'NULL') {
-                    fields.push('"' + key + '" IS ' + filterValue);
-                } else if (conds[key].constructor.name === 'Object') {
-                    var condType = Object.keys(conds[key])[0];
+        if (typeof conds === 'string') {
+            fields.push(conds);
+        } else if (util.isArray(conds)) {
+            var query = conds.shift().replace(/\?/g, function (s) {
+                return escape(conds.shift());
+            });
+            fields.push(query);
+        } else {
+            Object.keys(conds).forEach(function (key) {
+                if (filter.where[key] && filter.where[key].constructor.name === 'RegExp') {
+                    var regex = filter.where[key];
                     var sqlCond = '"' + key + '"';
-                    if ((condType == 'inq' || condType == 'nin') && filterValue.length == 0) {
-                        fields.push(condType == 'inq' ? 'FALSE' : 'TRUE');
-                        return true;
+
+                    if (regex.ignoreCase) {
+                        sqlCond += ' ~* ';
+                    } else {
+                        sqlCond += ' ~ ';
                     }
-                    switch (condType) {
-                        case 'gt':
-                            sqlCond += ' > ';
-                            break;
-                        case 'gte':
-                            sqlCond += ' >= ';
-                            break;
-                        case 'lt':
-                            sqlCond += ' < ';
-                            break;
-                        case 'lte':
-                            sqlCond += ' <= ';
-                            break;
-                        case 'between':
-                            sqlCond += ' BETWEEN ';
-                            break;
-                        case 'inq':
-                            sqlCond += ' IN ';
-                            break;
-                        case 'nin':
-                            sqlCond += ' NOT IN ';
-                            break;
-                        case 'neq':
-                            sqlCond += ' != ';
-                            break;
-                        case 'like':
-                            sqlCond += ' LIKE ';
-                            break;
-                        case 'nlike':
-                            sqlCond += ' NOT LIKE ';
-                            break;
-                        default:
-                            sqlCond += ' ' + condType + ' ';
-                            break;
-                    }
-                    sqlCond += (condType == 'inq' || condType == 'nin') ? '(' + filterValue + ')' : filterValue;
+
+                    sqlCond += "'"+regex.source+"'";
+
                     fields.push(sqlCond);
-                } else {
-                    fields.push('"' + key + '" = ' + filterValue);
+
+                    return;
                 }
-            }
-        }.bind(this));
+                if (props[key]) {
+                    var filterValue = this.toDatabase(props[key], filter.where[key]);
+                    if (filterValue === 'NULL') {
+                        fields.push('"' + key + '" IS ' + filterValue);
+                    } else if (conds[key].constructor.name === 'Object') {
+                        var condType = Object.keys(conds[key])[0];
+                        var sqlCond = '"' + key + '"';
+                        if ((condType == 'inq' || condType == 'nin') && filterValue.length == 0) {
+                            fields.push(condType == 'inq' ? 'FALSE' : 'TRUE');
+                            return true;
+                        }
+                        switch (condType) {
+                            case 'gt':
+                                sqlCond += ' > ';
+                                break;
+                            case 'gte':
+                                sqlCond += ' >= ';
+                                break;
+                            case 'lt':
+                                sqlCond += ' < ';
+                                break;
+                            case 'lte':
+                                sqlCond += ' <= ';
+                                break;
+                            case 'between':
+                                sqlCond += ' BETWEEN ';
+                                break;
+                            case 'inq':
+                                sqlCond += ' IN ';
+                                break;
+                            case 'nin':
+                                sqlCond += ' NOT IN ';
+                                break;
+                            case 'neq':
+                                sqlCond += ' != ';
+                                break;
+                            case 'like':
+                                sqlCond += ' LIKE ';
+                                break;
+                            case 'nlike':
+                                sqlCond += ' NOT LIKE ';
+                                break;
+                            default:
+                                sqlCond += ' ' + condType + ' ';
+                                break;
+                        }
+                        sqlCond += (condType == 'inq' || condType == 'nin') ? '(' + filterValue + ')' : filterValue;
+                        fields.push(sqlCond);
+                    } else {
+                        fields.push('"' + key + '" = ' + filterValue);
+                    }
+                }
+            }.bind(this));
+        }
+        
         if (fields.length) {
             out += ' WHERE ' + fields.join(' AND ');
         }

--- a/test/postgres.js
+++ b/test/postgres.js
@@ -64,3 +64,31 @@ test.it('all should support \'not like\' operator ', function (test) {
         });
     });
 });
+
+test.it('all should support arbitrary where clauses', function (test) {
+    Post = schema.models.Post;
+    Post.destroyAll(function () {
+        Post.create({title:'Postgres Test Title'}, function (err, post) {
+            var id = post.id;
+            Post.all({where:"title = 'Postgres Test Title'"}, function (err, post) {
+                test.ok(!err);
+                test.ok(post[0].id == id);
+                test.done();
+            });
+        });
+    });
+});
+
+test.it('all should support arbitrary parameterized where clauses', function (test) {
+    Post = schema.models.Post;
+    Post.destroyAll(function () {
+        Post.create({title:'Postgres Test Title'}, function (err, post) {
+            var id = post.id;
+            Post.all({where:['title = ?', 'Postgres Test Title']}, function (err, post) {
+                test.ok(!err);
+                test.ok(post[0].id == id);
+                test.done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
This pull request adds support for the following query styles:

```
Post.all({ where: "title = 'Foo' OR title = 'Bar'" })
```

and

```
Post.all({ where: ['title = ? OR title = ?', 'Foo', 'Bar'] })
```
