### PR TITLE
order asc/desc bug fixed

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -337,7 +337,7 @@ PG.prototype.toFilter = function (model, filter) {
         var t = filter.order.split(/\s+/);
         filter.order = [];
         t.forEach(function(token) {
-            if (token.match(/ASC|DESC/i)) {
+            if (token.match(/^ASC$|^DESC$/i)) {
                 filter.order[filter.order.length - 1] += ' ' + token;
             } else {
                 filter.order.push('"' + token + '"');


### PR DESCRIPTION
If you sort a query by some field starting with asc or desc (like ascend or descent) it is wrongly detected.
