### PR TITLE
Fix: heterogeneous and non-UTC time zones

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -157,22 +157,6 @@ PG.prototype.toFields = function (model, data, forCreate) {
     }
 };
 
-function dateToPostgres(val) {
-    return [
-        val.getUTCFullYear(),
-        fz(val.getUTCMonth() + 1),
-        fz(val.getUTCDate())
-    ].join('-') + ' ' + [
-        fz(val.getUTCHours()),
-        fz(val.getUTCMinutes()),
-        fz(val.getUTCSeconds())
-    ].join(':');
-
-    function fz(v) {
-        return v < 10 ? '0' + v : v;
-    }
-}
-
 PG.prototype.toDatabase = function (prop, val) {
     if (val === null || val === undefined) {
         // Postgres complains with NULLs in not null columns
@@ -218,10 +202,11 @@ PG.prototype.toDatabase = function (prop, val) {
                 return 'NULL';
             }
         }
-        if (!val.toUTFString) {
-            val = new Date(val);
+        if (!val.toISOString) {
+             val = new Date(val);
         }
-        return escape(dateToPostgres(val));
+        var iso = escape(val.toISOString()).substring(1);
+        return 'TIMESTAMP WITH TIME ZONE ' + iso;
     }
     return escape(val.toString());
 
@@ -637,7 +622,7 @@ function datatype(p) {
         case 'Number':
         return 'integer';
         case 'Date':
-        return 'timestamp';
+        return 'timestamp with time zone';
         case 'Boolean':
         return 'boolean';
     }


### PR DESCRIPTION
Yep, the timezone-related changes in my last pull request were incomplete. This completes the job.

There are three different timezone-related situations:
1. The timezones between client and server at the same, and are UTC. That works in master right now.
2. The timezones are the same, but they are not UTC. That worked with the last pull request, but is failing now.
3. The timezones are different. The additional changes in this pull request handle that. I've tested with GMT client and server, PDT client and server, GMT server and PDT client, as well as a smattering of other combinations. The key is to make the server think about time zones.

Basically, we use "WITH TIME ZONE" for our timestamp columns in postgres because that forces postgres to include timezone info when it returns those dates to us. That ensures that the dates are correct when we parse them out. This stackoverflow answer sums it up nicely: http://stackoverflow.com/a/17562423
