### PR TITLE
Support for "IS NOT NULL" queries.

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -281,9 +281,7 @@ PG.prototype.toFilter = function (model, filter) {
                 }
                 if (props[key]) {
                     var filterValue = this.toDatabase(props[key], filter.where[key]);
-                    if (filterValue === 'NULL') {
-                        fields.push('"' + key + '" IS ' + filterValue);
-                    } else if (conds[key].constructor.name === 'Object') {
+                    if (conds[key].constructor.name === 'Object') {
                         var condType = Object.keys(conds[key])[0];
                         var sqlCond = '"' + key + '"';
                         if ((condType == 'inq' || condType == 'nin') && filterValue.length == 0) {
@@ -313,7 +311,11 @@ PG.prototype.toFilter = function (model, filter) {
                                 sqlCond += ' NOT IN ';
                                 break;
                             case 'neq':
-                                sqlCond += ' != ';
+                                if (filterValue === 'NULL') {
+                                  sqlCond += ' IS NOT ';
+                                } else {
+                                  sqlCond += ' != ';
+                                }
                                 break;
                             case 'like':
                                 sqlCond += ' LIKE ';
@@ -328,7 +330,11 @@ PG.prototype.toFilter = function (model, filter) {
                         sqlCond += (condType == 'inq' || condType == 'nin') ? '(' + filterValue + ')' : filterValue;
                         fields.push(sqlCond);
                     } else {
-                        fields.push('"' + key + '" = ' + filterValue);
+                        if (filterValue === 'NULL') {
+                          fields.push('"' + key + '" IS ' + filterValue);
+                        } else {
+                          fields.push('"' + key + '" = ' + filterValue);
+                        }
                     }
                 }
             }.bind(this));

--- a/test/postgres.test.js
+++ b/test/postgres.test.js
@@ -105,3 +105,17 @@ test.it('all should support arbitrary parameterized where clauses', function (te
         });
     });
 });
+
+test.it('all should support \'not equal\' operator for NULL values', function (test) {
+    Post = schema.models.Post;
+    Post.destroyAll(function () {
+        Post.create({title:'Postgres Test Title'}, function (err, post) {
+            var id = post.id
+            Post.all({where:{title:{neq:null}}}, function (err, post) {
+                test.ok(!err);
+                test.ok(post[0].id == id);
+                test.done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Added support for "IS NOT NULL" queries. At current state only "IS NULL" queries were supported and there was no way to create "IS NOT NULL" query without using string filters
