### PR TITLE
param value should not modified in function

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -183,6 +183,7 @@ PG.prototype.toDatabase = function (prop, val) {
             return this.toDatabase(prop, val[0]) + ' AND ' + this.toDatabase(prop, val[1]);
         }
         if (operator === 'inq' || operator === 'nin') {
+            val = val.slice(0)
             for (var i = 0; i < val.length; i++) {
                 val[i] = escape(val[i]);
             }


### PR DESCRIPTION
in the `inq` condition, developer may use the original array to compare if every value is found in DB. It is not friendly to modify param value directly.
