### PR TITLE
readded support for connection strings

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -8,11 +8,17 @@ var util = require('util');
 exports.initialize = function initializeSchema(schema, callback) {
     if (!pg) return;
     var settings = {};
-    'password host port database poolSize ssl'.split(' ').forEach(function(k) {
-        settings[k] = schema.settings[k];
-    });
+    if (schema.settings.url) {
+        // compatibility with 0.0.4, connect using connection strings:
+        // postgres://username:password@host:port/database
+        settings = schema.settings.url;
+    } else {
+        'password host port database poolSize ssl'.split(' ').forEach(function(k) {
+            settings[k] = schema.settings[k];
+        });
 
-    settings.user = schema.settings.username;
+        settings.user = schema.settings.username;
+    }
 
     schema.adapter = new PG();
     schema.adapter.schema = schema;


### PR DESCRIPTION
Version 0.0.4 allowed users to specify connection details via a "connection string" by passing it into the schema settings as `{url: "..."}`. This readds that ability for backward compatibility. This is functionality is also necessary for users running on heroku since database details are provided to the app via an environment variable in the connection string format.
